### PR TITLE
Adding private option to tags

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1152,6 +1152,7 @@
   "set_date_of_birth": "Set date of birth",
   "set_profile_picture": "Set profile picture",
   "set_slideshow_to_fullscreen": "Set Slideshow to fullscreen",
+  "set_tag_private": "Make tag private",
   "settings": "Settings",
   "settings_saved": "Settings saved",
   "share": "Share",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -12533,6 +12533,10 @@
             "pattern": "^#?([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$",
             "type": "string"
           },
+          "isPrivate": {
+            "default": false,
+            "type": "boolean"
+          },
           "name": {
             "type": "string"
           },
@@ -12543,6 +12547,7 @@
           }
         },
         "required": [
+          "isPrivate",
           "name"
         ],
         "type": "object"
@@ -12558,6 +12563,9 @@
           },
           "id": {
             "type": "string"
+          },
+          "isPrivate": {
+            "type": "boolean"
           },
           "name": {
             "type": "string"
@@ -12588,8 +12596,19 @@
             "nullable": true,
             "pattern": "^#?([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$",
             "type": "string"
+          },
+          "isPrivate": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
           }
         },
+        "required": [
+          "isPrivate",
+          "name"
+        ],
         "type": "object"
       },
       "TagUpsertDto": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -12600,14 +12600,10 @@
           "isPrivate": {
             "default": false,
             "type": "boolean"
-          },
-          "name": {
-            "type": "string"
           }
         },
         "required": [
-          "isPrivate",
-          "name"
+          "isPrivate"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1316,8 +1316,6 @@ export type TagBulkAssetsResponseDto = {
 };
 export type TagUpdateDto = {
     color?: string | null;
-    name: string;
-    parentId?: string | null;
     isPrivate?: boolean;
 };
 export type TimeBucketResponseDto = {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -234,6 +234,7 @@ export type TagResponseDto = {
     parentId?: string;
     updatedAt: string;
     value: string;
+    isPrivate?: boolean;
 };
 export type AssetResponseDto = {
     /** base64 encoded sha1 hash */
@@ -1301,6 +1302,7 @@ export type TagCreateDto = {
     color?: string;
     name: string;
     parentId?: string | null;
+    isPrivate?: boolean;
 };
 export type TagUpsertDto = {
     tags: string[];
@@ -1314,6 +1316,9 @@ export type TagBulkAssetsResponseDto = {
 };
 export type TagUpdateDto = {
     color?: string | null;
+    name: string;
+    parentId?: string | null;
+    isPrivate?: boolean;
 };
 export type TimeBucketResponseDto = {
     count: number;

--- a/server/src/dtos/tag.dto.ts
+++ b/server/src/dtos/tag.dto.ts
@@ -14,7 +14,6 @@ export class TagCreateDto {
 
   @IsHexColor()
   @Optional({ nullable: true, emptyToNull: true })
-  @Transform(({ value }) => (typeof value === 'string' && value[0] !== '#' ? `#${value}` : value))
   color?: string;
 
   @IsBoolean()
@@ -22,10 +21,6 @@ export class TagCreateDto {
 }
 
 export class TagUpdateDto {
-  @IsString()
-  @IsNotEmpty()
-  name!: string;
-
   @Optional({ nullable: true, emptyToNull: true })
   @IsHexColor()
   @Transform(({ value }) => (typeof value === 'string' && value[0] !== '#' ? `#${value}` : value))

--- a/server/src/dtos/tag.dto.ts
+++ b/server/src/dtos/tag.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsHexColor, IsNotEmpty, IsString } from 'class-validator';
+import {IsBoolean, IsHexColor, IsNotEmpty, IsString} from 'class-validator';
 import { TagEntity } from 'src/entities/tag.entity';
 import { Optional, ValidateUUID } from 'src/validation';
 
@@ -14,14 +14,25 @@ export class TagCreateDto {
 
   @IsHexColor()
   @Optional({ nullable: true, emptyToNull: true })
+  @Transform(({ value }) => (typeof value === 'string' && value[0] !== '#' ? `#${value}` : value))
   color?: string;
+
+  @IsBoolean()
+  isPrivate: boolean = false;
 }
 
 export class TagUpdateDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
   @Optional({ nullable: true, emptyToNull: true })
   @IsHexColor()
   @Transform(({ value }) => (typeof value === 'string' && value[0] !== '#' ? `#${value}` : value))
   color?: string | null;
+
+  @IsBoolean()
+  isPrivate: boolean = false;
 }
 
 export class TagUpsertDto {
@@ -51,6 +62,7 @@ export class TagResponseDto {
   createdAt!: Date;
   updatedAt!: Date;
   color?: string;
+  isPrivate?: boolean;
 }
 
 export function mapTag(entity: TagEntity): TagResponseDto {
@@ -62,5 +74,6 @@ export function mapTag(entity: TagEntity): TagResponseDto {
     createdAt: entity.createdAt,
     updatedAt: entity.updatedAt,
     color: entity.color ?? undefined,
+    isPrivate: entity.isPrivate ?? false,
   };
 }

--- a/server/src/entities/tag.entity.ts
+++ b/server/src/entities/tag.entity.ts
@@ -50,4 +50,7 @@ export class TagEntity {
 
   @ManyToMany(() => AssetEntity, (asset) => asset.tags, { onUpdate: 'CASCADE', onDelete: 'CASCADE' })
   assets?: AssetEntity[];
+
+  @Column({type: 'boolean', default: false })
+  isPrivate?: boolean;
 }

--- a/server/src/migrations/1736492514982-AddPrivateTag.ts
+++ b/server/src/migrations/1736492514982-AddPrivateTag.ts
@@ -4,7 +4,7 @@ export class AddPrivateTag1736492514982 implements MigrationInterface {
     name = 'AddPrivateTag1736492514982'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "tags" ADD "isPrivate" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "tags" ADD "isPrivate" boolean NOT NULL DEFAULT true`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/server/src/migrations/1736492514982-AddPrivateTag.ts
+++ b/server/src/migrations/1736492514982-AddPrivateTag.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPrivateTag1736492514982 implements MigrationInterface {
+    name = 'AddPrivateTag1736492514982'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tags" ADD "isPrivate" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tags" DROP COLUMN "isPrivate"`);
+    }
+
+}

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -44,12 +44,14 @@ export class TagService extends BaseService {
 
     const userId = auth.user.id;
     const value = parent ? `${parent.value}/${dto.name}` : dto.name;
+    const color = dto.color;
+    const isPrivate = dto.isPrivate;
     const duplicate = await this.tagRepository.getByValue(userId, value);
     if (duplicate) {
       throw new BadRequestException(`A tag with that name already exists`);
     }
 
-    const tag = await this.tagRepository.create({ userId, value, parent });
+    const tag = await this.tagRepository.create({ userId, value, parent, color, isPrivate });
 
     return mapTag(tag);
   }
@@ -57,8 +59,9 @@ export class TagService extends BaseService {
   async update(auth: AuthDto, id: string, dto: TagUpdateDto): Promise<TagResponseDto> {
     await this.requireAccess({ auth, permission: Permission.TAG_UPDATE, ids: [id] });
 
-    const { color } = dto;
-    const tag = await this.tagRepository.update({ id, color });
+    const { color, isPrivate, name: value } = dto;
+
+    const tag = await this.tagRepository.update({ id, color, value, isPrivate });
     return mapTag(tag);
   }
 

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -44,24 +44,24 @@ export class TagService extends BaseService {
 
     const userId = auth.user.id;
     const value = parent ? `${parent.value}/${dto.name}` : dto.name;
-    const color = dto.color;
     const isPrivate = dto.isPrivate;
     const duplicate = await this.tagRepository.getByValue(userId, value);
     if (duplicate) {
       throw new BadRequestException(`A tag with that name already exists`);
     }
 
-    const tag = await this.tagRepository.create({ userId, value, parent, color, isPrivate });
+    const tag = await this.tagRepository.create({ userId, value, parent, isPrivate });
 
     return mapTag(tag);
   }
 
   async update(auth: AuthDto, id: string, dto: TagUpdateDto): Promise<TagResponseDto> {
+    console.log("updating tag");
     await this.requireAccess({ auth, permission: Permission.TAG_UPDATE, ids: [id] });
 
-    const { color, isPrivate, name: value } = dto;
+    const { color, isPrivate } = dto;
 
-    const tag = await this.tagRepository.update({ id, color, value, isPrivate });
+    const tag = await this.tagRepository.update({ id, color, isPrivate });
     return mapTag(tag);
   }
 

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -18,7 +18,7 @@
   import { AppRoute, AssetAction, QueryParameter, SettingInputFieldType } from '$lib/constants';
   import { AssetStore } from '$lib/stores/assets.store';
   import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
-  import {deleteTag, getAllTags, updateTag, type TagResponseDto, VideoCodec, createTag} from '@immich/sdk';
+  import { createTag, deleteTag, getAllTags, updateTag, type TagResponseDto } from '@immich/sdk';
   import { mdiPencil, mdiPlus, mdiTag, mdiTagMultiple, mdiTrashCanOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
@@ -76,22 +76,19 @@
   const navigateToView = (path: string) => goto(getLink(path));
 
   let isNewOpen = $state(false);
-  let tagName = $state('');
-  let tagColor = $state('');
+  let newTagValue = $state('');
   let isTagPrivate = $state(false);
 
   const handleCreate = () => {
-    tagName = tag ? tag.value + '/' : '';
+    newTagValue = tag ? tag.value + '/' : '';
     isNewOpen = true;
-    tagColor = tag?.color ?? '';
     isTagPrivate = tag?.isPrivate ?? false;
   };
 
   let isEditOpen = $state(false);
-
+  let newTagColor = $state('');
   const handleEdit = () => {
-    tagName = tag?.value + '/' ?? '';
-    tagColor = tag?.color ?? '';
+    newTagColor = tag?.color ?? '';
     isEditOpen = true;
     isTagPrivate = tag?.isPrivate ?? false;
   };
@@ -102,9 +99,8 @@
   };
 
   const handleSubmit = async () => {
-    if (tag && isEditOpen && tagColor) {
-      await updateTag({ id: tag.id, tagUpdateDto: { color: tagColor, name: tagName, isPrivate: isTagPrivate } });
-
+    if (tag && isEditOpen) {
+      await updateTag({ id: tag.id, tagUpdateDto: { color: newTagColor, isPrivate: isTagPrivate } });
       notificationController.show({
         message: $t('tag_updated', { values: { tag: tag.value } }),
         type: NotificationType.Info,
@@ -114,8 +110,8 @@
       isEditOpen = false;
     }
 
-    if (isNewOpen && tagName) {
-      const newTag = await createTag({ tagCreateDto: { color: tagColor, name: tagName, isPrivate: isTagPrivate }});
+    if (isNewOpen && newTagValue) {
+      const newTag = await createTag({ tagCreateDto: { name: newTagValue, isPrivate: isTagPrivate }});
 
       notificationController.show({
         message: $t('tag_created', { values: { tag: newTag.value } }),
@@ -230,16 +226,11 @@
         <SettingInputField
           inputType={SettingInputFieldType.TEXT}
           label={$t('tag').toUpperCase()}
-          bind:value={tagName}
+          bind:value={newTagValue}
           required={true}
           autofocus={true}
         />
       </div>
-      <SettingInputField
-        inputType={SettingInputFieldType.COLOR}
-        label={$t('color').toUpperCase()}
-        bind:value={tagColor}
-      />
       <div class="my-4 flex flex-col gap-2">
         <SettingSwitch title={$t('set_tag_private')} bind:checked={isTagPrivate} />
       </div>
@@ -257,18 +248,9 @@
     <form {onsubmit} autocomplete="off" id="edit-tag-form">
       <div class="my-4 flex flex-col gap-2">
         <SettingInputField
-          inputType={SettingInputFieldType.TEXT}
-          label={$t('tag').toUpperCase()}
-          bind:value={tagName}
-          required={true}
-          autofocus={true}
-        />
-      </div>
-      <div class="my-4 flex flex-col gap-2">
-        <SettingInputField
           inputType={SettingInputFieldType.COLOR}
           label={$t('color').toUpperCase()}
-          bind:value={tagColor}
+          bind:value={newTagColor}
         />
       </div>
       <div class="my-4 flex flex-col gap-2">


### PR DESCRIPTION
This change adds a private toggle for tags. By default, existing tags will have a tag's `isPrivate` value set to `true` while new tags (when created) will default to `false`. This is part of a change that is intended to support app-wide tags in addition to private, per-user tags (as they are now).

This change also updates how the "create tag" functionality works, calling `createTag` instead of `upsertTag`. This was done to more accurately reflect the action and simplify passing in the params.